### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ## Broccoli Unwatched Tree
 
+**Deprecated in favor of
+[broccoli-source](https://github.com/broccolijs/broccoli-source).**
+
 This is useful if you would like to use a given directory, but not have it polled/watched when running
 `broccoli serve` (or `ember server` if using Ember CLI).
 


### PR DESCRIPTION
broccoli-source has
- a new name
- both UnwatchedDir and WatchedDir (the latter to replace plain strings)
- and a future-proof API

for extra fance.
